### PR TITLE
refactor: Realiza el cambio al header y menu de navegación

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container autosize="true">
-  <mat-sidenav opened="true" mode="side">
+  <mat-sidenav [opened]="abrir" mode="side" *ngIf="isMenuRequired">
     <div class="logo" fxLayout fxLayoutGap="20px" fxLayoutAlign="start center">
       <mat-icon>face</mat-icon>
       <h3 *ngIf="expanded">Sistema de Gestión</h3>
@@ -7,7 +7,7 @@
     <cer-menu (onToggleExpanded)="toggleExpanded($event)"></cer-menu>
   </mat-sidenav>
   <mat-sidenav-content>
-    <cer-header></cer-header>
+    <cer-header *ngIf="isHeaderRequired"></cer-header>
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,40 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
 
 @Component({
   selector: 'cer-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
+  isMenuRequired = false;
+  isHeaderRequired = false;
   title = 'CertyGet';
   expanded = true;
+  abrir = false;
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        this.handleNavigation(event.urlAfterRedirects || event.url);
+      }
+    });
+  }
+
+  private handleNavigation(url: string): void {
+    if (url === '/login') {
+      this.abrir = false;
+      this.expanded = false;
+      this.isHeaderRequired = false;
+      this.isMenuRequired = false;
+    } else {
+      this.isHeaderRequired = true;
+      this.isMenuRequired = true;
+      this.abrir = true;
+    }
+  }
 
   toggleExpanded(expanded: boolean) {
     this.expanded = expanded;


### PR DESCRIPTION
Modifica el header y el menu de navegación en función a la pantalla de login, por favor revisar y aprobar.
![imagen_2023-12-03_221108056](https://github.com/KevinCayo10/Certyget/assets/75343631/37a71cab-9db7-4a50-8246-dbe92ccd964e)
